### PR TITLE
Print a message explaning the warning still printed by ASP.NET Core.

### DIFF
--- a/src/linux-dev-certs/Program.cs
+++ b/src/linux-dev-certs/Program.cs
@@ -24,7 +24,16 @@ installCommand.SetHandler((InvocationContext ctx) =>
     bool isSuccess = certManager.InstallAndTrust(installDeps);
     if (isSuccess)
     {
+        ConsoleColor color = Console.ForegroundColor;
+
+        Console.ForegroundColor = ConsoleColor.Green;
         Console.WriteLine("The development certificate was successfully installed.");
+
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("ASP.NET Core applications may still print a warning at startup that the develper certificate is not trusted.");
+        Console.WriteLine("This is a false warning. The message is no longer printed with ASP.NET Core 9 preview 6+.");
+
+        Console.ForegroundColor = color;
     }
     ctx.ExitCode = isSuccess ? 0 : 1;
 });


### PR DESCRIPTION
Fixes https://github.com/tmds/linux-dev-certs/issues/23.