### PR TITLE
Update IsArchLike to include Cachyos support

### DIFF
--- a/src/linux-dev-certs/OSFlavor.cs
+++ b/src/linux-dev-certs/OSFlavor.cs
@@ -5,7 +5,7 @@ static class OSFlavor
 {
     public static bool IsFedoraLike => MatchesId("fedora");
     public static bool IsDebianLike => MatchesId("debian");
-    public static bool IsArchLike => MatchesId("arch");
+    public static bool IsArchLike => MatchesId("arch") || MatchesId("cachyos");
     public static bool IsGentooLike => MatchesId("gentoo");
     public static bool IsSlackLike => MatchesId("slackware");
 


### PR DESCRIPTION
CachyOS is an arch system but its ID reports as cachyos instead of arch. so should be a safe change